### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#iOS Chat room demo with Parse.com server side#
+# iOS Chat room demo with Parse.com server side #
 
 This project was set up as a complete source for the tutorial entitled: "iOS Tutorial: Creating a chat room using Parse.com" that can be found on my [personal blog](http://attila.tumblr.com). Here's a view of what is created:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
